### PR TITLE
Use actual test duration to populate the `time` attribute in reports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ The following report is an example of a test class that was composed of 3 tests,
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="example.package.TestClass" errors="1" failures="1" tests="3">
-    <testcase classname="example.package.TestClass" name="My module: First test" assertions="1">
+  <testsuite name="example.package.TestClass" errors="1" failures="1" tests="3" time="0.04">
+    <testcase classname="example.package.TestClass" name="My module: First test" assertions="1" time="0.01">
     </testcase>
-    <testcase classname="example.package.TestClass" name="My module: Second test" assertions="2">
+    <testcase classname="example.package.TestClass" name="My module: Second test" assertions="2" time="0.02">
     </testcase>
-    <testcase classname="example.package.TestClass" name="My module: Third test" assertions="2">
+    <testcase classname="example.package.TestClass" name="My module: Third test" assertions="2" time="0.01">
       <error type="failed" message="Died on test #1: Can't find variable: other">
     at http://localhost:8000/vendor/qunit-1.12.0.js:425
     at http://localhost:8000/test/example/package/TestClass.test.js:29

--- a/lib/XmlReporter.js
+++ b/lib/XmlReporter.js
@@ -8,7 +8,10 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('underscore'),
+
+    // Force tests to report a duration > 0.01 seconds.
+    minimumTestDurationMs = (0.01 * 1000);
 
 function XmlReporter() {
 
@@ -21,21 +24,34 @@ _.extend(XmlReporter.prototype, {
             .replace(/"/g, '&quot;');
     },
 
+    sumTestsuiteDuration: function (tests) {
+        return _.reduce(tests, function (soFar, test) {
+            return soFar + Math.max(test.duration, minimumTestDurationMs);
+        }, 0);
+    },
+
+    formatDuration: function (ms) {
+        return (isFinite(ms) && ms > minimumTestDurationMs) ? (ms / 1000).toFixed(2) : "0.01";
+    },
+
     generateReport: function (result) {
-        var xml = '<?xml version="1.0" encoding="UTF-8"?>\n<testsuites>\n';
+        var xml = '<?xml version="1.0" encoding="UTF-8"?>\n<testsuites>\n',
+            suiteDuration;
         _.each(result.modules, function (module) {
+            suiteDuration = this.sumTestsuiteDuration(module.tests);
             xml += '\t<testsuite'
                 + ' name="' + this.escape(result.classname) + '"'
                 + ' errors="' + module.errored + '"'
                 + ' failures="' + module.failed + '"'
                 + ' tests="' + module.tests.length + '"'
-                + ' time="0.01">\n';
+                + ' time="' + this.formatDuration(suiteDuration) + '">\n';
             _.each(module.tests, function (test) {
                 xml += '\t\t<testcase'
                     + ' classname="' + this.escape(result.classname) + '"'
                     + ' name="' + this.escape(
                         (module.name ? (module.name + ": ") : "") + test.name) + '"'
-                    + ' assertions="' + test.total + '" time="0.01">\n';
+                    + ' assertions="' + test.total + '"'
+                    + ' time="' + this.formatDuration(test.duration) + '">\n';
                 _.each(test.logs, function (data) {
                     xml += '\t\t\t<' + data.type + ' type="failed" message="'
                         + this.escape(data.message) + '">\n';

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-connect": "~0.5.0",
-    "grunt-contrib-qunit": "~0.3.0",
+    "grunt-contrib-qunit": "~0.5.2",
     "diff": "~1.0.8"
   },
   "keywords": [

--- a/tasks/qunit-junit.js
+++ b/tasks/qunit-junit.js
@@ -112,13 +112,14 @@ module.exports = function (grunt) {
             }
         },
 
-        handleTestDone: function (name, failed, passed, total) {
+        handleTestDone: function (name, failed, passed, total, duration) {
             this.tests.push({
                 name: name,
                 errored: this.currentErrors,
                 failed: failed - this.currentErrors,
                 passed: passed,
                 total: total,
+                duration: duration,
                 logs: this.currentLogs
             });
 

--- a/test/expected/custom_namer/TEST-example.Exciting.xml
+++ b/test/expected/custom_namer/TEST-example.Exciting.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite name="example.Exciting" errors="0" failures="2" tests="2" time="0.01">
+	<testsuite name="example.Exciting" errors="0" failures="2" tests="2" time="0.02">
 		<testcase classname="example.Exciting" name="a failing test example" assertions="1" time="0.01">
 			<failure type="failed" message="We expect to fail">
 			</failure>
@@ -10,7 +10,7 @@
 			</failure>
 		</testcase>
 	</testsuite>
-	<testsuite name="example.Exciting" errors="0" failures="1" tests="3" time="0.01">
+	<testsuite name="example.Exciting" errors="0" failures="1" tests="4" time="0.53">
 		<testcase classname="example.Exciting" name="Module 19: A failing test that checks XML encoding" assertions="1" time="0.01">
 			<failure type="failed" message="A quote: &quot;We expect to fail&quot;">
 			</failure>
@@ -18,6 +18,8 @@
 		<testcase classname="example.Exciting" name="Module 19: a basic test example" assertions="1" time="0.01">
 		</testcase>
 		<testcase classname="example.Exciting" name="Module 19: another basic test example" assertions="1" time="0.01">
+		</testcase>
+		<testcase classname="example.Exciting" name="Module 19: an async test example" assertions="1" time="0.50">
 		</testcase>
 	</testsuite>
 	<testsuite name="example.Exciting" errors="1" failures="0" tests="1" time="0.01">

--- a/test/expected/custom_namer/TEST-example.Mixed.xml
+++ b/test/expected/custom_namer/TEST-example.Mixed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite name="example.Mixed" errors="0" failures="2" tests="3" time="0.01">
+	<testsuite name="example.Mixed" errors="0" failures="2" tests="3" time="0.03">
 		<testcase classname="example.Mixed" name="Module 19: a basic test example" assertions="1" time="0.01">
 		</testcase>
 		<testcase classname="example.Mixed" name="Module 19: a failing test example" assertions="1" time="0.01">

--- a/test/expected/defaults/TEST-Exciting.xml
+++ b/test/expected/defaults/TEST-Exciting.xml
@@ -10,7 +10,7 @@
 			</failure>
 		</testcase>
 	</testsuite>
-	<testsuite name="Exciting" errors="0" failures="1" tests="3" time="0.01">
+	<testsuite name="Exciting" errors="0" failures="1" tests="4" time="0.53">
 		<testcase classname="Exciting" name="Module 19: A failing test that checks XML encoding" assertions="1" time="0.01">
 			<failure type="failed" message="A quote: &quot;We expect to fail&quot;">
 			</failure>
@@ -18,6 +18,8 @@
 		<testcase classname="Exciting" name="Module 19: a basic test example" assertions="1" time="0.01">
 		</testcase>
 		<testcase classname="Exciting" name="Module 19: another basic test example" assertions="1" time="0.01">
+		</testcase>
+		<testcase classname="Exciting" name="Module 19: an async test example" assertions="1" time="1.50">
 		</testcase>
 	</testsuite>
 	<testsuite name="Exciting" errors="1" failures="0" tests="1" time="0.01">

--- a/test/expected/defaults/TEST-Mixed.xml
+++ b/test/expected/defaults/TEST-Mixed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite name="Mixed" errors="0" failures="2" tests="3" time="0.01">
+	<testsuite name="Mixed" errors="0" failures="2" tests="3" time="0.03">
 		<testcase classname="Mixed" name="Module 19: a basic test example" assertions="1" time="0.01">
 		</testcase>
 		<testcase classname="Mixed" name="Module 19: a failing test example" assertions="1" time="0.01">

--- a/test/expected/single_html/TEST-mixed.xml
+++ b/test/expected/single_html/TEST-mixed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite name="mixed" errors="0" failures="2" tests="3" time="0.01">
+	<testsuite name="mixed" errors="0" failures="2" tests="3" time="0.03">
 		<testcase classname="mixed" name="Module 19: a basic test example" assertions="1" time="0.01">
 		</testcase>
 		<testcase classname="mixed" name="Module 19: a failing test example" assertions="1" time="0.01">

--- a/test/fixtures/common/exciting.js
+++ b/test/fixtures/common/exciting.js
@@ -24,6 +24,14 @@ setTimeout(function () {
         equal(value, "hello", "We expect value to be hello" );
     });
 
+    asyncTest('an async test example', function() {
+        var value = "world";
+        setTimeout(function() {
+            equal(value, "world", "We expect value to be world");
+            start();
+        }, 500);
+    });
+
     module("Module 20");
 
     // This should have a stack trace!


### PR DESCRIPTION
Use the test duration value supplied by QUnit to populate the `time` attribute in the report.
- `grunt-contrib-qunit` 0.5.2 includes a duration param in the `qunit.testDone` event.
- Modified XmlReporter to convert the value from ms to a `X.yy` string formatted in seconds.
- Enforce a minimum time of `0.01` seconds for each test case
- Sum all tests to provide the total duration of each testsuite.
- Modify tests to provide fuzzy matching around times - this ensures that small variations in timing don't fail the suite.
