### PR TITLE
Multitask Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ In your project's Gruntfile, add a section named `qunit_junit` to the data objec
 
 ```js
 grunt.initConfig({
-
     qunit_junit: {
-        options: {
-            // Task-specific options go here.
+        all: {
+            options: {
+                // Task-specific options go here.
+            }
         }
     },
 })
@@ -124,7 +125,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
-* 0.3.0 added ability to provide custom url, module and test namers.
+* 0.3.0 added ability to provide custom url, module and test namers, changed to be a multi-task
 * 0.2.0 updated `grunt-contrib-qunit` to 0.5.2 to report actual test durations.
 * 0.1.1 added time attribute to output with dummy value, to aid compatibility
 * 0.1.0 is available for general use.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
-* 0.3.0 added ability to provide custom url, module and test namers, changed to be a multi-task
+* 0.3.0 added ability to provide custom url, module and test namers
 * 0.2.0 updated `grunt-contrib-qunit` to 0.5.2 to report actual test durations.
 * 0.1.1 added time attribute to output with dummy value, to aid compatibility
 * 0.1.0 is available for general use.

--- a/tasks/qunit-junit.js
+++ b/tasks/qunit-junit.js
@@ -186,7 +186,7 @@ module.exports = function (grunt) {
     });
 
 
-    grunt.registerTask('qunit_junit',
+    grunt.registerMultiTask('qunit_junit',
             'Log JUnit style XML reports for QUnit tests', function () {
         var options = this.options({
                 dest: '_build/test-reports',

--- a/test/tasks/tester.js
+++ b/test/tasks/tester.js
@@ -92,7 +92,7 @@ module.exports = function (grunt) {
             qunitConfig.options.urls = settings.urls;
         }
         grunt.log.ok("Performing setup for " + name);
-        grunt.config('qunit_junit.options', settings.options);
+        grunt.config('qunit_junit.all.options', settings.options);
         grunt.config.set('qunit.all', qunitConfig);
     };
 
@@ -220,7 +220,7 @@ module.exports = function (grunt) {
             grunt.config('harness.teardown_' + name,
                     _.bind(teardownSuite, null, name, settings, errors[name]));
 
-            grunt.task.run('harness:setup_' + name, 'qunit_junit', 'qunit:all',
+            grunt.task.run('harness:setup_' + name, 'qunit_junit:all', 'qunit:all',
                 'harness:teardown_' + name);
         });
 

--- a/test/tasks/tester.js
+++ b/test/tasks/tester.js
@@ -92,7 +92,7 @@ module.exports = function (grunt) {
             qunitConfig.options.urls = settings.urls;
         }
         grunt.log.ok("Performing setup for " + name);
-        grunt.config('qunit_junit.all.options', settings.options);
+        grunt.config('qunit_junit.' + name + '.options', settings.options);
         grunt.config.set('qunit.all', qunitConfig);
     };
 
@@ -220,7 +220,7 @@ module.exports = function (grunt) {
             grunt.config('harness.teardown_' + name,
                     _.bind(teardownSuite, null, name, settings, errors[name]));
 
-            grunt.task.run('harness:setup_' + name, 'qunit_junit:all', 'qunit:all',
+            grunt.task.run('harness:setup_' + name, 'qunit_junit:' + name, 'qunit:all',
                 'harness:teardown_' + name);
         });
 


### PR DESCRIPTION
This modifies the qunit_junit task to be a multitask so users can specify alternative configuration if they are executing a number of qunit passes in a single build.

This scratches an itch I have where I run 2 test passes for unit and integration tests and want to write the output to a different directory.