### PR TITLE
Fix #20 - QueryString included in report filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Specify where the XML reports should be saved to.
 
 #### options.fileNamer
 Type: `Function`
-Default value: `function (url) { return path.basename(url).replace(/\.html$/, ''); }`
+Default value: `function (url) { return path.basename(url).replace(/\.html(.*)$/, ''); }`
 
-Specify a function that converts test URLs into destination filenames.  Note that filenames are automatically prefixed with 'TEST-' and given a '.xml' extension.
+Specify a function that converts test URLs into destination filenames.  Note that filenames are automatically prefixed with 'TEST-' and given a '.xml' extension.  The default implementation uses the name of the HTML test-runner, discarding the query string.
 
 #### options.classNamer
 Type `Function`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-qunit-junit",
   "description": "Produce JUnit XML reports for QUnit tests",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/sbrandwoo/grunt-qunit-junit",
   "author": {
     "name": "Stephen Brandwood",

--- a/tasks/qunit-junit.js
+++ b/tasks/qunit-junit.js
@@ -191,7 +191,7 @@ module.exports = function (grunt) {
         var options = this.options({
                 dest: '_build/test-reports',
                 fileNamer: function (url) {
-                    return path.basename(url).replace(/\.html$/, '');
+                    return path.basename(url).replace(/\.html(.*)$/, '');
                 },
                 classNamer: function (moduleName, url) {
                     return moduleName.replace(/[\\|\/]/g, '.').replace(/\s+/g, '_');

--- a/test/expected/default_filenamer_ignores_querystring/TEST-testrunner.xml
+++ b/test/expected/default_filenamer_ignores_querystring/TEST-testrunner.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="Module_21" errors="0" failures="0" tests="1" time="0.01">
+		<testcase classname="Module_21" name="a basic test example" assertions="1" time="0.01">
+		</testcase>
+	</testsuite>
+</testsuites>

--- a/test/tasks/tester.js
+++ b/test/tasks/tester.js
@@ -70,6 +70,15 @@ module.exports = function (grunt) {
 
                 actual: '_build/single_html',
                 expected: 'test/expected/single_html'
+            },
+            default_filenamer_ignores_querystring: {
+                options: {
+                    dest: '_build/default_filenamer_ignores_querystring'
+                },
+                urls: [ 'http://localhost:8017/fixtures/single_html/'
+                        + 'testrunner.html?test=success&noGlobals=true' ],
+                actual: '_build/default_filenamer_ignores_querystring',
+                expected: 'test/expected/default_filenamer_ignores_querystring'
             }
         };
 


### PR DESCRIPTION
Modify the default `fileNamer` regexp to remove anything after `.html`, including the trailing querystring.